### PR TITLE
Add 18 to the list of required OTP versions

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "R13B04|R14|R15|R16|17"}.
+{require_otp_vsn, "R13B04|R14|R15|R16|17|18"}.
 
 {erl_opts, [debug_info, warn_unused_vars, warn_shadow_vars, warn_unused_import]}.
 {port_env, [


### PR DESCRIPTION
This just bumps the list of required OTP versions to make it work on newer Erlang/OTP 18.
